### PR TITLE
Fixed `frame_id` in usb_cam params

### DIFF
--- a/robot_bringup/config/usb_cam_params.yaml
+++ b/robot_bringup/config/usb_cam_params.yaml
@@ -3,13 +3,13 @@
       video_device: "/dev/c270"
       framerate: 30.0
       io_method: "mmap"
-      frame_id: "camera"
+      frame_id: "c270"
       pixel_format: "mjpeg2rgb"  # see usb_cam/supported_formats for list of supported formats
       av_device_format: "YUV422P"
       image_width: 1280
       image_height: 960
       camera_name: "c270"
-      camera_info_url: "package://robot_bringup/config/camera_info.yaml"
+      camera_info_url: "file:///ros2_ws/src/robot_bringup/config/camera_info.yaml"
       brightness: -1
       contrast: -1
       saturation: -1


### PR DESCRIPTION
## Brief
In this PR
- Fixed `frame_id` in usb_cam params, would cause issues in viewing `Camera` data (refer 3058cae890452abd9492ec80b6ca0122e747d68c)